### PR TITLE
Highlight current month and de-emphasize past events

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -181,7 +181,6 @@ defaults:
       type: events
     values:
       layout: event
-      show_date: true
       excerpt: ''
       sidebar:
         nav: events

--- a/_layouts/collection-year-calendar.html
+++ b/_layouts/collection-year-calendar.html
@@ -33,6 +33,7 @@ div.monthcard {
 
 div.current {
   background-color: #e2e4e5;
+  border-width: 2px;
 }
 
 h3.monthlabel {
@@ -72,6 +73,11 @@ td.dim {
 tr.dim {
   background-color: rgba(226, 228, 229, 0.5);
 }
+
+tr.current td,
+tr.current a {
+  font-weight: bold;
+}
 </style>
 
 <script>
@@ -102,9 +108,7 @@ function getPageYear() {
 }
 
 function dimAllMonths() {
-    for (let i = 1; i <= 12; ++i) {
-        dimAllEventsOfMonth(i);
-    }
+    for (let i = 1; i <= 12; ++i) dimAllEventsOfMonth(i);
 }
 
 function dimAllEventsOfMonth(month) {
@@ -126,6 +130,32 @@ function dimEvent(event, idx) {
     let [dayCell, eventLinkCell] = event.children;
     dayCell.classList.add("dim");
     eventLinkCell.firstElementChild.classList.add("dim");
+}
+
+function dimPastMonthsAndHighlightCurrent(curMonth, curDay) {
+    for (let i = 1; i < curMonth; ++i) dimAllEventsOfMonth(i);
+    highlightCurrentMonth(curMonth, curDay);
+}
+
+function highlightCurrentMonth(month, curDay) {
+    let monthDiv = document.getElementById(`month${month}`);
+    monthDiv.classList.add("current");
+
+    let events = [...monthDiv.getElementsByTagName("tr")];
+
+    events
+        .filter(event => event.children[0].textContent < curDay)
+        .forEach(dimEvent);
+
+    let today = events.find(event => event.children[0].textContent == curDay);
+
+    if (today == undefined) return;
+
+    highlightDay(today);
+}
+
+function highlightDay(dayRow) {
+    dayRow.classList.add("current");
 }
 </script>
 

--- a/_layouts/collection-year-calendar.html
+++ b/_layouts/collection-year-calendar.html
@@ -5,6 +5,7 @@ layout: archive
 <style>
 :root {
   --num-columns: 1;
+  --dim-foreground: rgba(34, 40, 49, 0.44);
 }
 
 @media (min-width: 500px) {
@@ -38,7 +39,7 @@ h3.monthlabel {
   margin-top: .5em;
 }
 
-table tr:nth-child(even) {
+table tr:nth-child(even):not(.dim) {
   background-color: #e2e4e5;
 }
 
@@ -57,16 +58,75 @@ tr td:first-child {
 tr td:last-child {
   width: 100%;
 }
+
+div.dim {
+  border-color: var(--dim-foreground);
+}
+
+a.dim,
+h3.dim,
+td.dim {
+  color: var(--dim-foreground);
+}
+
+tr.dim {
+  background-color: rgba(226, 228, 229, 0.5);
+}
 </style>
 
 <script>
-function highlightMonth() {
-    let curMonth = new Date().getMonth() + 1;
-    let curMonthDiv = document.getElementById(`month${curMonth}`);
-    curMonthDiv.classList.add("current");
+window.addEventListener("load", highlightCalendar);
+
+function highlightCalendar() {
+    let now = new Date();
+    let curYear = now.getFullYear();
+    let pageYear = getPageYear();
+
+    if (pageYear > curYear) return;
+
+    if (pageYear < curYear) {
+        dimAllMonths();
+        return;
+    }
+
+    let curMonth = now.getMonth() + 1;
+    let curDay = now.getDate();
+
+    dimPastMonthsAndHighlightCurrent(curMonth, curDay);
 }
 
-window.addEventListener("load", highlightMonth);
+function getPageYear() {
+    let title = document.getElementById("page-title");
+
+    return title.textContent.trim().split(" ")[0];
+}
+
+function dimAllMonths() {
+    for (let i = 1; i <= 12; ++i) {
+        dimAllEventsOfMonth(i);
+    }
+}
+
+function dimAllEventsOfMonth(month) {
+    let monthDiv = document.getElementById(`month${month}`);
+    dimMonthNameAndBorder(monthDiv);
+
+    let events = monthDiv.getElementsByTagName("tr");
+    [...events].forEach(dimEvent);
+}
+
+function dimMonthNameAndBorder(monthDiv) {
+    monthDiv.classList.add("dim");
+    let monthName = monthDiv.firstElementChild;
+    monthName.classList.add("dim");
+}
+
+function dimEvent(event, idx) {
+    if (idx % 2) event.classList.add("dim");
+    let [dayCell, eventLinkCell] = event.children;
+    dayCell.classList.add("dim");
+    eventLinkCell.firstElementChild.classList.add("dim");
+}
 </script>
 
 {%- assign posts = site[page.collection]

--- a/_layouts/collection-year-calendar.html
+++ b/_layouts/collection-year-calendar.html
@@ -30,12 +30,20 @@ div.monthcard {
   padding: 5%;
 }
 
+div.current {
+  background-color: #e2e4e5;
+}
+
 h3.monthlabel {
   margin-top: .5em;
 }
 
 table tr:nth-child(even) {
   background-color: #e2e4e5;
+}
+
+div.current table tr:nth-child(even) {
+  background-color: #eeeeee;
 }
 
 tr td {
@@ -51,6 +59,16 @@ tr td:last-child {
 }
 </style>
 
+<script>
+function highlightMonth() {
+    let curMonth = new Date().getMonth() + 1;
+    let curMonthDiv = document.getElementById(`month${curMonth}`);
+    curMonthDiv.classList.add("current");
+}
+
+window.addEventListener("load", highlightMonth);
+</script>
+
 {%- assign posts = site[page.collection]
   | group_by_exp: "item", "item.date | date: '%Y'"
   | where: "name", page.year
@@ -60,7 +78,7 @@ tr td:last-child {
 <div class="calendar">
   {%- for month in (1..12) -%}
     {%- capture datestamp %}{{ page.year }}-{{ month }}-01{% endcapture %}
-    <div id="month{{ month | prepend: '0' | slice: -2, 2 }}" class="monthcard">
+    <div id="month{{ month }}" class="monthcard">
       <h3 class="monthlabel">{{ datestamp | date: "%B" }}</h3>
       <hr>
       {%- assign monthposts = posts

--- a/_layouts/collection-year-calendar.html
+++ b/_layouts/collection-year-calendar.html
@@ -95,10 +95,7 @@ function highlightCalendar() {
         return;
     }
 
-    let curMonth = now.getMonth() + 1;
-    let curDay = now.getDate();
-
-    dimPastMonthsAndHighlightCurrent(curMonth, curDay);
+    dimPastMonthsAndHighlightCurrent(now);
 }
 
 function getPageYear() {
@@ -132,7 +129,10 @@ function dimEvent(event, idx) {
     eventLinkCell.firstElementChild.classList.add("dim");
 }
 
-function dimPastMonthsAndHighlightCurrent(curMonth, curDay) {
+function dimPastMonthsAndHighlightCurrent(now) {
+    let curMonth = now.getMonth() + 1;
+    let curDay = now.getDate();
+
     for (let i = 1; i < curMonth; ++i) dimAllEventsOfMonth(i);
     highlightCurrentMonth(curMonth, curDay);
 }
@@ -142,16 +142,18 @@ function highlightCurrentMonth(month, curDay) {
     monthDiv.classList.add("current");
 
     let events = [...monthDiv.getElementsByTagName("tr")];
-
-    events
-        .filter(event => event.children[0].textContent < curDay)
-        .forEach(dimEvent);
+    dimPastEvents(events, curDay);
 
     let today = events.find(event => event.children[0].textContent == curDay);
-
     if (today == undefined) return;
 
     highlightDay(today);
+}
+
+function dimPastEvents(events, curDay) {
+    events
+        .filter(event => event.children[0].textContent < curDay)
+        .forEach(dimEvent);
 }
 
 function highlightDay(dayRow) {


### PR DESCRIPTION
Add CSS to dim past events, highlight the current month (and potentially day), and add JavaScript to check the current date and apply the classes correspondingly.

Example view if today were June 17, 2018:

![image](https://user-images.githubusercontent.com/8521043/193474183-d56460d4-125b-41e0-8001-7ea9349d5f95.png)