### PR TITLE
Automate "last modified" timestamps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby File.read(".ruby-version").strip
 gem "jekyll"
 gem "jekyll-feed"
 gem "jekyll-include-cache"
+gem "jekyll-last-modified-at"
 gem "jekyll-paginate"
 gem "jekyll-redirect-from"
 gem "jekyll-remote-theme"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,9 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-last-modified-at (1.3.0)
+      jekyll (>= 3.7, < 5.0)
+      posix-spawn (~> 0.3.9)
     jekyll-paginate (1.1.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
@@ -75,6 +78,7 @@ GEM
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    posix-spawn (0.3.15)
     public_suffix (5.0.0)
     racc (1.6.0)
     rb-fsevent (0.11.2)
@@ -100,6 +104,7 @@ DEPENDENCIES
   jekyll
   jekyll-feed
   jekyll-include-cache
+  jekyll-last-modified-at
   jekyll-paginate
   jekyll-redirect-from
   jekyll-remote-theme

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 # Plugins
 plugins:
   - jekyll-feed
+  - jekyll-last-modified-at
   - jekyll-include-cache
   - jekyll-paginate
   - jekyll-redirect-from

--- a/_events/2014-08-16-annual-soccer.md
+++ b/_events/2014-08-16-annual-soccer.md
@@ -2,6 +2,5 @@
 title: Annual soccer tournament
 location: Fogolars Country Club Oakville
 address: 2026 Lower Base Line, Oakville, ON L6M
-last_modified_at: 2022-06-11
 date: 2014-08-16
 ---

--- a/_events/2014-09-07-raclette.md
+++ b/_events/2014-09-07-raclette.md
@@ -4,7 +4,6 @@ location: Fogolars Country Club Oakville
 address: 2026 Lower Base Line, Oakville, ON L6M
 start_time: 12:00 pm
 end_time: 1:00 pm
-last_modified_at: 2022-06-11
 date: 2014-09-07
 ---
 

--- a/_events/2014-09-13-concert-tour-by.md
+++ b/_events/2014-09-13-concert-tour-by.md
@@ -5,7 +5,6 @@ address: 65 Church Street, Toronto, ON M5C 2E9
 start_time: 7:00 pm
 end_time: 8:00 pm
 web_url: http://www.knabenkantorei.ch
-last_modified_at: 2022-06-11
 date: 2014-09-13
 ---
 

--- a/_events/2014-09-14-concert-tour.md
+++ b/_events/2014-09-14-concert-tour.md
@@ -5,7 +5,6 @@ address: 227 Bloor Street East, Toronto, ON M4W
 start_time: 11 am
 end_time: 12 pm
 web_url: http://www.knabenkantorei.ch
-last_modified_at: 2022-06-11
 date: 2014-09-14
 ---
 

--- a/_events/2014-09-14-zoo-walk-and-picnic.md
+++ b/_events/2014-09-14-zoo-walk-and-picnic.md
@@ -9,7 +9,6 @@ cost: |
   $24.35 for adults
   $15.65 for children
   $17.40 for seniors
-last_modified_at: 2022-06-19
 date: 2014-09-14
 ---
 

--- a/_events/2014-10-07-kalyna-rakel.md
+++ b/_events/2014-10-07-kalyna-rakel.md
@@ -5,7 +5,6 @@ address: 70 Adelaide Street West, Toronto, ON M5V 2E2
 start_time: 8:00 pm
 end_time: 9:00 pm
 web_url: https://www.parlour270.com
-last_modified_at: 2022-06-11
 teaser: /assets/images/2014-10-07-kalyna-teaser.jpg
 date: 2014-10-07
 ---

--- a/_events/2014-10-08-summer-games-giochi.md
+++ b/_events/2014-10-08-summer-games-giochi.md
@@ -6,7 +6,6 @@ start_time: 6:30 pm
 end_time: 7:30 pm
 web_url: https://iictoronto.esteri.it/IIC_Toronto/en/
 web_url_name: Istituto Italiano di Cultura Toronto
-last_modified_at: 2022-06-11
 date: 2014-10-08
 ---
 

--- a/_events/2014-11-15-swiss-canadian.md
+++ b/_events/2014-11-15-swiss-canadian.md
@@ -5,7 +5,6 @@ address: 37 King Street East, Toronto, ON M5C
 start_time: 7:00 pm
 end_time: 1:00 am
 end_date: 2014-11-16
-last_modified_at: 2022-06-11
 date: 2014-11-15
 ---
 

--- a/_events/2014-11-20-deutschschweizer-film.md
+++ b/_events/2014-11-20-deutschschweizer-film.md
@@ -7,7 +7,6 @@ end_time: 9:00 pm
 cost: |
   $8 per person
   Includes coffee and and cake after the movie, served by the Women’s section
-last_modified_at: 2022-06-19
 date: 2014-11-20
 ---
 

--- a/_events/2014-12-05-canadian-swiss.md
+++ b/_events/2014-12-05-canadian-swiss.md
@@ -7,7 +7,6 @@ end_time: 10:00 pm
 cost: |
   Seniors: $45.75
   Regular price: $61.00
-last_modified_at: 2022-06-19
 date: 2014-12-05
 ---
 

--- a/_events/2014-12-06-pre-christmas-social.md
+++ b/_events/2014-12-06-pre-christmas-social.md
@@ -9,7 +9,6 @@ web_url_name: Marché Brookfield Place
 cost: |
   $10 per person
   Kids are free
-last_modified_at: 2022-06-19
 date: 2014-12-06
 ---
 

--- a/_events/2015-01-24-amicale-romande.md
+++ b/_events/2015-01-24-amicale-romande.md
@@ -5,7 +5,6 @@ address: 2100 Jane Street, North York, ON M3M 1A1
 start_time: 7:00 pm
 end_date: 2015-01-25
 end_time: 1:00 am
-last_modified_at: 2022-06-11
 date: 2015-01-24
 ---
 

--- a/_events/2015-01-25-jass-section-th.md
+++ b/_events/2015-01-25-jass-section-th.md
@@ -2,7 +2,6 @@
 title: Jass section 15th annual Saujass
 start_time: 1:00 pm
 end_time: 5:00 pm
-last_modified_at: 2022-06-11
 date: 2015-01-25
 ---
 

--- a/_events/2015-02-06-swiss-club-toronto.md
+++ b/_events/2015-02-06-swiss-club-toronto.md
@@ -4,6 +4,5 @@ location: Musket Restaurant; banquet room
 address: 40 Advance Road, Etobicoke, ON M8Z 2T4
 start_time: 7:00 pm
 end_time: 10:00 pm
-last_modified_at: 2022-06-11
 date: 2015-02-06
 ---

--- a/_events/2015-02-21-morgenstraich.md
+++ b/_events/2015-02-21-morgenstraich.md
@@ -4,7 +4,6 @@ location: Musket Restaurant
 address: 40 Advance Road, Etobicoke, ON M8Z 2T4
 start_time: 6:00 am
 end_time: 9:00 am
-last_modified_at: 2022-06-11
 date: 2015-02-21
 ---
 

--- a/_events/2015-02-28-costume-ball.md
+++ b/_events/2015-02-28-costume-ball.md
@@ -5,7 +5,6 @@ address: 40 Advance Road, Etobicoke, ON M8Z 2T4
 start_time: 7:00 pm
 end_date: 2015-03-01
 end_time: 1:00 am
-last_modified_at: 2022-06-11
 date: 2015-02-28
 ---
 

--- a/_events/2015-03-08-the-mouse-house.md
+++ b/_events/2015-03-08-the-mouse-house.md
@@ -5,7 +5,6 @@ address: 2190 Bloor Street West, Toronto, ON M6S 1N3
 start_time: 2:00 pm
 end_time: 5:00 pm
 cost: $18
-last_modified_at: 2022-06-11
 date: 2015-03-08
 ---
 

--- a/_events/2015-04-19-swiss-theater-group.md
+++ b/_events/2015-04-19-swiss-theater-group.md
@@ -4,7 +4,6 @@ location: Estonian House
 address: 958 Broadview Avenue, East York, ON M4K 2R6
 start_time: 2:00 pm
 end_time: 6:00 pm
-last_modified_at: 2022-06-19
 cost: |
   Members: $15
   Non-members: $20

--- a/_events/2015-05-03-new-play-called.md
+++ b/_events/2015-05-03-new-play-called.md
@@ -4,7 +4,6 @@ location: The Village Playhouse
 address: 2100 Bloor Street West, Toronto, ON M6S
 start_time: 2:00 pm
 end_time: 4:00 pm
-last_modified_at: 2022-06-11
 date: 2015-05-03
 ---
 

--- a/_events/2015-05-14-gardiner-museum.md
+++ b/_events/2015-05-14-gardiner-museum.md
@@ -6,7 +6,6 @@ start_time: 1:00 pm
 end_time: 2:30 pm
 web_url: https://www.gardinermuseum.on.ca
 web_url_name: Gardiner Museum
-last_modified_at: 2022-06-11
 date: 2015-05-14
 ---
 

--- a/_events/2015-06-05-woodbine-racetrack.md
+++ b/_events/2015-06-05-woodbine-racetrack.md
@@ -7,7 +7,6 @@ end_time: 6:00 pm
 web_url: https://web.archive.org/web/20150302043906/http://www.woodbineentertainment.com/WOODBINE/Pages/Default.aspx
 web_url_name: Woodbine
 cost: $40; includes delicious lunch and $10 to play slot machines
-last_modified_at: 2022-06-19
 date: 2015-06-05
 ---
 

--- a/_events/2015-06-09-swiss-canadian.md
+++ b/_events/2015-06-09-swiss-canadian.md
@@ -4,7 +4,6 @@ location: King's Riding Golf Club
 address: King City, ON L7B 1K5
 web_url: https://www.swissbiz.ca/upcoming_events.php
 web_url_name: SCCC upcoming events
-last_modified_at: 2022-06-11
 date: 2015-06-09
 ---
 

--- a/_events/2015-06-27-family-bbq.md
+++ b/_events/2015-06-27-family-bbq.md
@@ -4,7 +4,6 @@ location: Egger Farms
 address: 5244 Steeles Avenue West, Milton, ON L9T 2Y1
 start_time: 1:00 pm
 end_time: 4:00 pm
-last_modified_at: 2022-06-11
 date: 2015-06-27
 ---
 

--- a/_events/2015-07-26-swiss-national-day.md
+++ b/_events/2015-07-26-swiss-national-day.md
@@ -8,6 +8,5 @@ teaser: /assets/images/2015-07-26-national-day-teaser.jpg
 cost: |
   Members & children: free
   Non-members: $10
-last_modified_at: 2022-06-19
 date: 2015-07-26
 ---

--- a/_events/2015-08-15-annual-soccer.md
+++ b/_events/2015-08-15-annual-soccer.md
@@ -4,7 +4,6 @@ location: Fogolars Country Club
 address: 2026 Lower Baseline Road, Oakville, ON L6M
 start_time: 9:00 am
 end_time: 6:00 pm
-last_modified_at: 2022-06-11
 web_url: https://web.archive.org/web/20150801143850/http://www.fogolarscountryclub.com/
 web_url_name: Fogolars Country Club
 date: 2015-08-15

--- a/_events/2015-09-19-zoo-walk.md
+++ b/_events/2015-09-19-zoo-walk.md
@@ -10,7 +10,6 @@ cost: |
   Child (ages 3--12): $18.00
   Child (ages 2 and younger): free
 teaser: /assets/images/2015-09-19-zoo-teaser.jpg
-last_modified_at: 2022-06-19
 date: 2015-09-19
 ---
 

--- a/_events/2015-09-26-th-anniversary.md
+++ b/_events/2015-09-26-th-anniversary.md
@@ -6,7 +6,6 @@ start_time: 2:00 pm
 end_time: 4:00 pm
 web_url: https://web.archive.org/web/20150920023406/http://www.swissmaster.com/
 web_url_name: Swiss-Master Chocolatier
-last_modified_at: 2022-06-11
 date: 2015-09-26
 ---
 

--- a/_events/2015-10-08-on-va-marcher-sur.md
+++ b/_events/2015-10-08-on-va-marcher-sur.md
@@ -5,7 +5,6 @@ address: 2 Sussex Dr, Etobicoke, ON M8V 1W4
 start_time: 6:45 pm
 end_time: 10:00 pm
 teaser: /assets/images/2015-10-08-everest-teaser.jpg
-last_modified_at: 2022-06-11
 date: 2015-10-08
 ---
 

--- a/_events/2015-12-05-toronto-christmas.md
+++ b/_events/2015-12-05-toronto-christmas.md
@@ -5,7 +5,6 @@ address: The Distillery District, Toronto, ON M5A
 start_time: 4:00 pm
 web_url: https://www.torontochristmasmarket.com
 cost: $5
-last_modified_at: 2022-06-19
 date: 2015-12-05
 ---
 

--- a/_events/2016-01-17-saujass.md
+++ b/_events/2016-01-17-saujass.md
@@ -2,7 +2,6 @@
 title: Saujass
 start_time: 1:00 pm
 end_time: 5:15 pm
-last_modified_at: 2022-06-12
 date: 2016-01-17
 ---
 

--- a/_events/2016-01-30-the-annual-fondue-amp.md
+++ b/_events/2016-01-30-the-annual-fondue-amp.md
@@ -3,7 +3,6 @@ title: Amicale Romande fondue & dance
 location: Saint Phillipe Neri Church
 address: 2100 Jane St, North York, ON M3M 1A1
 start_time: 7:00 pm
-last_modified_at: 2022-06-12
 date: 2016-01-30
 ---
 

--- a/_events/2016-02-13-canadysli-anniversary.md
+++ b/_events/2016-02-13-canadysli-anniversary.md
@@ -6,7 +6,6 @@ start_time: 7:00 am
 end_time: 11:30 am
 web_url: https://www.canadysli.com
 web_url_name: Canadysli website
-last_modified_at: 2022-06-12
 date: 2016-02-13
 ---
 

--- a/_events/2016-02-20-canadysli-toronto.md
+++ b/_events/2016-02-20-canadysli-toronto.md
@@ -5,7 +5,6 @@ address: 40 Advance Rd, Etobicoke, ON M8Z 2T4
 start_time: 7:00 pm
 web_url: https://www.canadysli.com
 web_url_name: Canadysli website
-last_modified_at: 2022-06-12
 date: 2016-02-20
 ---
 

--- a/_events/2016-02-21-bloor-yorkvilles-th.md
+++ b/_events/2016-02-21-bloor-yorkvilles-th.md
@@ -3,7 +3,6 @@ title: Bloor--Yorkville’s 10th Annual Icefest
 location: Nespresso Boutique Bar
 address: 159 Cumberland St, Toronto, ON M5R
 start_time: 2:00 pm
-last_modified_at: 2022-06-12
 date: 2016-02-21
 ---
 

--- a/_events/2016-02-26-annual-general.md
+++ b/_events/2016-02-26-annual-general.md
@@ -3,7 +3,6 @@ title: Annual general meeting 2016
 location: The Musket Restaurant, banquet room
 address: 40 Advance Rd, Etobicoke, ON M8Z 2T4
 start_time: 7:00 pm
-last_modified_at: 2022-06-12
 date: 2016-02-26
 ---
 

--- a/_events/2016-04-24-theatre-group-kei.md
+++ b/_events/2016-04-24-theatre-group-kei.md
@@ -9,7 +9,6 @@ cost: |
   Non-members: $20
   Youth: $10 (children free)
 teaser: /assets/images/2016-04-24-regel-teaser.png
-last_modified_at: 2022-06-19
 date: 2016-04-24
 ---
 

--- a/_events/2016-05-18-television-museum.md
+++ b/_events/2016-05-18-television-museum.md
@@ -8,7 +8,6 @@ web_url: https://mztv.com
 web_url_name: MZTV Museum of Television website
 contact: Paula
 cost: $5
-last_modified_at: 2022-07-09
 date: 2016-05-18
 ---
 

--- a/_events/2016-06-10-woodbine-racetrack.md
+++ b/_events/2016-06-10-woodbine-racetrack.md
@@ -6,7 +6,6 @@ start_time: 12:00 pm
 contact: Paula
 web_url: https://woodbine.com/dining-at-woodbine/
 web_url_name: Dining at Woodbine
-last_modified_at: 2022-07-09
 date: 2016-06-10
 ---
 

--- a/_events/2016-06-18-annual-family-b-b-q.md
+++ b/_events/2016-06-18-annual-family-b-b-q.md
@@ -5,7 +5,6 @@ address: 5244 Steeles Ave W, Milton, ON L9T 2Y1
 contact: Arno
 start_time: 1:00 pm
 end_time: 4:00 pm
-last_modified_at: 2022-07-10
 date: 2016-06-18
 ---
 

--- a/_events/2016-07-24-august-st-celebration.md
+++ b/_events/2016-07-24-august-st-celebration.md
@@ -9,6 +9,5 @@ web_url: https://www.countryheritagepark.com
 web_url_name: Country Heritage Park
 cost: $10 for non-members
 teaser: /assets/images/2016-07-24-snd-teaser.jpg
-last_modified_at: 2022-07-10
 date: 2016-07-24
 ---

--- a/_events/2016-07-30-canoe-trip.md
+++ b/_events/2016-07-30-canoe-trip.md
@@ -3,7 +3,6 @@ title: Canoe trip
 end_date: 2022-08-01
 contact: Walter
 cost: About $80&ndash;$90
-last_modified_at: 2022-07-09
 date: 2016-07-30
 ---
 

--- a/_events/2016-08-06-visit-amp-reception.md
+++ b/_events/2016-08-06-visit-amp-reception.md
@@ -6,7 +6,6 @@ start_time: 2:00 pm
 end_time: 4:00 pm
 web_url: https://web.archive.org/web/20150304044245/https://stratfordperthheritage.ca/tavern.html
 web_url_name: Fryfogel Tavern (archive link)
-last_modified_at: 2022-06-12
 date: 2016-08-06
 ---
 

--- a/_events/2016-08-27-bike-amp-picnic-day.md
+++ b/_events/2016-08-27-bike-amp-picnic-day.md
@@ -6,7 +6,6 @@ contacts:
   - Sascha
 start_time: 10:30 am
 end_time: 3:00 pm
-last_modified_at: 2022-07-09
 date: 2016-08-27
 ---
 

--- a/_events/2016-08-28-bbq-boat-cruise.md
+++ b/_events/2016-08-28-bbq-boat-cruise.md
@@ -8,7 +8,6 @@ contact: Paula
 cost: |
   $45 members
   $50 non-members
-last_modified_at: 2022-07-10
 date: 2016-08-28
 ---
 

--- a/_events/2016-09-10-zoo-walk-at-toronto.md
+++ b/_events/2016-09-10-zoo-walk-at-toronto.md
@@ -6,7 +6,6 @@ start_time: T10:30
 contact: Denise
 web_url: https://www.torontozoo.com
 web_url_name: Toronto Zoo
-last_modified_at: 2022-07-09
 date: 2016-09-10
 ---
 

--- a/_events/2016-09-11-amicale-romande.md
+++ b/_events/2016-09-11-amicale-romande.md
@@ -6,7 +6,6 @@ contact: Jean-Marc
 cost: |
   $30 per person ($5 rebate for Swiss Club members)
   $5 for parking (charged by the park)
-last_modified_at: 2022-07-09
 date: 2016-09-11
 ---
 

--- a/_events/2016-11-20-swiss-movie-matinee.md
+++ b/_events/2016-11-20-swiss-movie-matinee.md
@@ -7,7 +7,6 @@ end_time: 6:30 pm
 cost: |
   Swiss Club members: free
   Non-members: $5
-last_modified_at: 2022-06-19
 date: 2016-11-20
 ---
 

--- a/_events/2016-12-10-toronto-christmas.md
+++ b/_events/2016-12-10-toronto-christmas.md
@@ -7,7 +7,6 @@ web_url: https://www.torontochristmasmarket.com
 web_url_name: Toronto Christmas Market
 start_time: 5:00 pm
 end_time: 10:00 pm
-last_modified_at: 2022-07-09
 date: 2016-12-10
 ---
 

--- a/_events/2017-01-22-jass-section-th.md
+++ b/_events/2017-01-22-jass-section-th.md
@@ -3,6 +3,5 @@ title: Jass section 16th annual Saujass
 start_time: 1:00 pm
 end_time: 5:30 pm
 contact: Albert
-last_modified_at: 2022-06-26
 date: 2017-01-22
 ---

--- a/_events/2017-01-28-amicale-romande.md
+++ b/_events/2017-01-28-amicale-romande.md
@@ -6,7 +6,6 @@ start_time: 7:00 pm
 end_date: 2017-01-29
 end_time: 1:00 am
 contact: Jean-Marc
-last_modified_at: 2022-06-26
 date: 2017-01-28
 ---
 

--- a/_events/2017-02-10-swiss-club-toronto.md
+++ b/_events/2017-02-10-swiss-club-toronto.md
@@ -7,7 +7,6 @@ end_time: 10:00 pm
 contact: Monika
 web_url: http://www.chelseatoronto.com/
 web_url_name: Chelsea Hotel
-last_modified_at: 2022-06-26
 date: 2017-02-10
 ---
 

--- a/_events/2017-04-30-theatre-group-toronto.md
+++ b/_events/2017-04-30-theatre-group-toronto.md
@@ -11,7 +11,6 @@ cost: |
   Children: free
 contact: Walter
 teaser: /assets/images/2017-04-30-theatre-teaser.png
-last_modified_at: 2022-06-26
 date: 2017-04-30
 ---
 

--- a/_events/2017-05-31-swiss-connections.md
+++ b/_events/2017-05-31-swiss-connections.md
@@ -7,7 +7,6 @@ end_time: 8:00 pm
 contact: Nadia
 web_url: https://www.facebook.com/events/409584076077277/
 web_url_name: Facebook event
-last_modified_at: 2022-06-26
 date: 2017-05-31
 ---
 

--- a/_events/2017-06-09-woodbine-racetrack.md
+++ b/_events/2017-06-09-woodbine-racetrack.md
@@ -5,7 +5,6 @@ address: 555 Rexdale Blvd, Etobicoke, ON M9W
 start_time: 11:30 am
 end_time: 2:30 pm
 contact: Paula
-last_modified_at: 2022-06-26
 date: 2017-06-09
 ---
 

--- a/_events/2017-06-17-annual-family-bar-b-q.md
+++ b/_events/2017-06-17-annual-family-bar-b-q.md
@@ -4,7 +4,6 @@ location: Egger Dairy Farm, Milton
 start_time: 1:00 pm
 end_time: 6:00 pm
 contact: Arno
-last_modified_at: 2022-06-26
 date: 2017-06-17
 ---
 

--- a/_events/2017-07-30-swiss-national-day.md
+++ b/_events/2017-07-30-swiss-national-day.md
@@ -8,6 +8,5 @@ cost: |
   Members & children: free
   Non-members: $10
 teaser: /assets/images/2017-07-30-snd-teaser.png
-last_modified_at: 2022-06-26
 date: 2017-07-30
 ---

--- a/_events/2017-08-13-tall-ship-kajama.md
+++ b/_events/2017-08-13-tall-ship-kajama.md
@@ -10,7 +10,6 @@ cost: |
   Non-members $42
 web_url: https://www.tallshipcruisestoronto.com/
 web_url_name: Tall Ship Cruises Toronto
-last_modified_at: 2022-06-26
 date: 2017-08-13
 ---
 

--- a/_events/2017-08-26-bike-amp-picnic-on.md
+++ b/_events/2017-08-26-bike-amp-picnic-on.md
@@ -6,7 +6,6 @@ start_time: 10:30 am
 end_time: 2:30 pm
 contact: Denise
 teaser: /assets/images/2017-08-26-island-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2017-08-26
 ---
 

--- a/_events/2017-09-09-zoo-walk-in-toronto.md
+++ b/_events/2017-09-09-zoo-walk-in-toronto.md
@@ -6,7 +6,6 @@ start_time: 10:30 am
 end_time: 2:30 pm
 contact: Denise
 teaser: /assets/images/2018-09-09-zoo-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2017-09-09
 ---
 

--- a/_events/2017-09-10-raclette.md
+++ b/_events/2017-09-10-raclette.md
@@ -9,6 +9,5 @@ cost: |
   $25 for Swiss Club members
   $30 for non-members
 teaser: /assets/images/2017-09-10-raclette-teaser.png
-last_modified_at: 2022-06-26
 date: 2017-09-10
 ---

--- a/_events/2017-10-14-autumn-train-ride.md
+++ b/_events/2017-10-14-autumn-train-ride.md
@@ -8,7 +8,6 @@ cost: |
   Non-members $90
 web_url: https://www.steamtrain.ca/
 web_url_name: South Simcoe Railway
-last_modified_at: 2022-06-26
 date: 2017-10-14
 ---
 

--- a/_events/2017-10-17-cocktails-and-film.md
+++ b/_events/2017-10-17-cocktails-and-film.md
@@ -10,7 +10,6 @@ contact:
 web_url: https://www.eda.admin.ch/montreal
 web_url_name: Consulate General of Switzerland in Montreal
 teaser: /assets/images/2017-10-17-vie-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2017-10-17
 ---
 

--- a/_events/2017-10-19-swiss-social-pub.md
+++ b/_events/2017-10-19-swiss-social-pub.md
@@ -6,7 +6,6 @@ start_time: 7:00 pm
 end_time: 9:00 pm
 web_url: https://www.facebook.com/events/1492186344152044/
 web_url_name: Facebook event
-last_modified_at: 2022-06-26
 date: 2017-10-19
 ---
 

--- a/_events/2017-11-19-movie-matinee-sunday.md
+++ b/_events/2017-11-19-movie-matinee-sunday.md
@@ -1,6 +1,5 @@
 ---
 title: Movie matinée
-last_modified_at: 2022-06-26
 date: 2017-11-19
 ---
 

--- a/_events/2017-11-22-swiss-social-pub.md
+++ b/_events/2017-11-22-swiss-social-pub.md
@@ -7,7 +7,6 @@ end_time: 9:00 pm
 web_url: https://www.facebook.com/events/1454152327987389/
 web_url_name: Facebook event
 teaser: /assets/images/2020-01-23-pub-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2017-11-22
 ---
 

--- a/_events/2017-12-02-niagara-falls.md
+++ b/_events/2017-12-02-niagara-falls.md
@@ -3,7 +3,6 @@ title: Festival of Lights & USA outlet
 location: Niagara Falls
 contact: Paula
 teaser: /assets/images/2017-12-02-niagara-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2017-12-02
 ---
 

--- a/_events/2017-12-09-christmas-market.md
+++ b/_events/2017-12-09-christmas-market.md
@@ -5,7 +5,6 @@ address: 55 Mill St, Toronto, ON M5A 3C4
 start_time: 5:00 pm
 end_time: 8:00 pm
 contact: Denise
-last_modified_at: 2022-06-26
 date: 2017-12-09
 ---
 

--- a/_events/2017-12-21-swiss-social-pub.md
+++ b/_events/2017-12-21-swiss-social-pub.md
@@ -7,7 +7,6 @@ end_time: 9:00 pm
 web_url: https://www.facebook.com/events/500676653633541
 web_url_name: Facebook event
 teaser: /assets/images/2020-01-23-pub-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2017-12-21
 ---
 

--- a/_events/2018-01-25-swiss-social-pub.md
+++ b/_events/2018-01-25-swiss-social-pub.md
@@ -7,7 +7,6 @@ end_time: 9:00 pm
 web_url: https://www.facebook.com/events/845215682311619/
 web_url_name: Facebook event
 teaser: /assets/images/2020-01-23-pub-teaser.jpg
-last_modified_at: 2022-06-19
 date: 2018-01-25
 ---
 

--- a/_events/2018-01-27-amicale-romande.md
+++ b/_events/2018-01-27-amicale-romande.md
@@ -6,7 +6,6 @@ address: 2100 Jane St, North York, ON M3M 1A1
 start_time: 7:00 pm
 end_time: 10:00 pm
 contact: Jean-Marc
-last_modified_at: 2022-06-19
 date: 2018-01-27
 ---
 

--- a/_events/2018-02-06-swiss-academics.md
+++ b/_events/2018-02-06-swiss-academics.md
@@ -9,7 +9,6 @@ contact: Thomas
 cost: $20
 web_url: https://ti.to/swiss-academics/left-field-brewery-tour
 web_url_name: Event website
-last_modified_at: 2022-06-19
 date: 2018-02-06
 ---
 

--- a/_events/2018-02-22-swiss-social-pub.md
+++ b/_events/2018-02-22-swiss-social-pub.md
@@ -7,7 +7,6 @@ start_time: 7:00 pm
 end_time: 9:00 pm
 web_url: https://www.facebook.com/events/969118416586879/
 web_url_name: Facebook event
-last_modified_at: 2022-06-19
 date: 2018-02-22
 ---
 

--- a/_events/2018-02-24-nd-annual-canadysli.md
+++ b/_events/2018-02-24-nd-annual-canadysli.md
@@ -9,6 +9,5 @@ contact: Philippe
 cost: |
   $45 in advance
   $50 at the door
-last_modified_at: 2022-06-19
 date: 2018-02-24
 ---

--- a/_events/2018-03-01-swiss-social.md
+++ b/_events/2018-03-01-swiss-social.md
@@ -7,7 +7,6 @@ start_time: 7:00 pm
 end_time: 10:00 pm
 contact: Nadia
 cost: $40
-last_modified_at: 2022-06-19
 date: 2018-03-01
 ---
 

--- a/_events/2018-03-11-tainted-justice-a.md
+++ b/_events/2018-03-11-tainted-justice-a.md
@@ -7,6 +7,5 @@ start_time: 2:00 pm
 end_time: 3:00 pm
 contact: Paula
 cost: $20 for seniors
-last_modified_at: 2022-06-19
 date: 2018-03-11
 ---

--- a/_events/2018-03-22-swiss-social-pub.md
+++ b/_events/2018-03-22-swiss-social-pub.md
@@ -7,7 +7,6 @@ start_time: 7:00 pm
 end_time: 9:00 pm
 web_url: https://www.facebook.com/events/428171877641525/
 web_url_name: Facebook event
-last_modified_at: 2022-06-19
 date: 2018-03-22
 ---
 

--- a/_events/2018-04-20-annual-general.md
+++ b/_events/2018-04-20-annual-general.md
@@ -7,7 +7,6 @@ end_time: 11:00 pm
 contact: Monika
 web_url: https://www.chelseatoronto.com/en
 web_url_name: Chelsea Hotel Toronto
-last_modified_at: 2022-06-19
 date: 2018-04-20
 ---
 

--- a/_events/2018-04-22-theatre-group.md
+++ b/_events/2018-04-22-theatre-group.md
@@ -8,7 +8,6 @@ end_time: 4:00 pm
 contacts:
   - Maggie
   - Walter
-last_modified_at: 2022-07-24
 date: 2018-04-22
 ---
 

--- a/_events/2018-04-26-swiss-social-pub.md
+++ b/_events/2018-04-26-swiss-social-pub.md
@@ -7,7 +7,6 @@ start_time: 7:00 pm
 end_time: 9:00 pm
 web_url: https://www.facebook.com/events/172062076737939/
 web_url_name: Facebook event
-last_modified_at: 2022-06-19
 date: 2018-04-26
 ---
 

--- a/_events/2018-05-13-cancelled-ottawa-tour.md
+++ b/_events/2018-05-13-cancelled-ottawa-tour.md
@@ -5,7 +5,6 @@ location: Ottawa
 end_date: 2018-05-14
 contact: Paula
 cost: $379--$529
-last_modified_at: 2022-06-19
 date: 2018-05-13
 ---
 

--- a/_events/2018-05-24-swiss-social-pub.md
+++ b/_events/2018-05-24-swiss-social-pub.md
@@ -8,7 +8,6 @@ end_time: 9:00 pm
 contact: Nadia
 event_url: https://www.facebook.com/events/1643910232313601/
 event_url_name: Facebook event
-last_modified_at: 2022-06-19
 date: 2018-05-24
 ---
 

--- a/_events/2018-06-08-lunch-at-woodbine.md
+++ b/_events/2018-06-08-lunch-at-woodbine.md
@@ -7,7 +7,6 @@ contact: Paula
 cost: |
   $42 (members)
   $47 (guests)
-last_modified_at: 2022-06-19
 date: 2018-06-08
 ---
 

--- a/_events/2018-06-13-scccbcctc-golf.md
+++ b/_events/2018-06-13-scccbcctc-golf.md
@@ -7,7 +7,6 @@ end_time: 9:00 pm
 cost: |
   $225 Individual
   $450 Twosome
-last_modified_at: 2022-06-19
 date: 2018-06-13
 ---
 

--- a/_events/2018-06-17-soccer-brazil.md
+++ b/_events/2018-06-17-soccer-brazil.md
@@ -5,7 +5,6 @@ location: The Rushton Pub
 address: 740 St Clair Ave W, Toronto, ON M6C 1B3k
 start_time: 1:00 pm
 contact: Nadia
-last_modified_at: 2022-06-19
 date: 2018-06-17
 ---
 

--- a/_events/2018-06-21-swiss-social-pub.md
+++ b/_events/2018-06-21-swiss-social-pub.md
@@ -8,7 +8,6 @@ end_time: 9:00 pm
 web_url: https://www.facebook.com/events/228238211254196/
 web_url_name: Facebook event
 contact: Nadia
-last_modified_at: 2022-06-19
 date: 2018-06-21
 ---
 

--- a/_events/2018-06-22-soccer-serbia.md
+++ b/_events/2018-06-22-soccer-serbia.md
@@ -5,7 +5,6 @@ location: The Rushton Pub
 address: 740 St Clair Ave W, Toronto, ON M6C 1B3
 start_time: 1:00 pm
 contact: Nadia
-last_modified_at: 2022-06-19
 date: 2018-06-22
 ---
 

--- a/_events/2018-06-23-mens-section-yearly.md
+++ b/_events/2018-06-23-mens-section-yearly.md
@@ -6,7 +6,6 @@ address: 5244 Steeles Ave W, Milton, ON L9T 2Y1
 start_time: 1:00 pm
 end_time: 5:00 pm
 contact: Arno
-last_modified_at: 2022-06-19
 date: 2018-06-23
 ---
 

--- a/_events/2018-06-27-soccer-costa-rica.md
+++ b/_events/2018-06-27-soccer-costa-rica.md
@@ -5,7 +5,6 @@ location: The Rushton Pub
 address: 740 St Clair Ave W, Toronto, ON M6C 1B3
 start_time: 1:00 pm
 contact: Nadia
-last_modified_at: 2022-06-19
 date: 2018-06-27
 ---
 

--- a/_events/2018-07-03-soccer-sweden.md
+++ b/_events/2018-07-03-soccer-sweden.md
@@ -5,7 +5,6 @@ location: The Rushton Pub
 address: 740 St Clair Ave W, Toronto, ON M6C 1B3k
 start_time: 9.30 am
 contact: Nadia
-last_modified_at: 2022-06-19
 date: 2018-07-03
 ---
 

--- a/_events/2018-07-19-swiss-social-pub.md
+++ b/_events/2018-07-19-swiss-social-pub.md
@@ -7,7 +7,6 @@ start_time: 7:00 pm
 contact: Nadia
 web_url: https://www.facebook.com/events/649472582058103/
 web_url_name: Facebook event
-last_modified_at: 2022-06-19
 date: 2018-07-19
 ---
 

--- a/_events/2018-07-29-swiss-national-day.md
+++ b/_events/2018-07-29-swiss-national-day.md
@@ -11,6 +11,5 @@ contact: Sascha
 cost: |
   Members & children: free
   Non-members: $10
-last_modified_at: 2022-06-19
 date: 2018-07-29
 ---

--- a/_events/2018-08-01-flag-raising-at-city.md
+++ b/_events/2018-08-01-flag-raising-at-city.md
@@ -9,7 +9,6 @@ web_url: https://www.swissbiz.ca/event_registration_p1.php?eid=137
 web_url_name: Event registration
 contact:
   name: Consulate of Switzerland in Toronto
-last_modified_at: 2022-06-19
 date: 2018-08-01
 ---
 

--- a/_events/2018-08-04-canoe-trip-to.md
+++ b/_events/2018-08-04-canoe-trip-to.md
@@ -5,7 +5,6 @@ location: Algonquin Provincial Park
 end_date: 2018-08-06
 contact: Walter
 cost: $80--$90
-last_modified_at: 2022-06-19
 date: 2018-08-04
 ---
 

--- a/_events/2018-08-16-swiss-social-pub.md
+++ b/_events/2018-08-16-swiss-social-pub.md
@@ -8,7 +8,6 @@ end_time: 9 pm
 contact: Nadia
 web_url: https://www.facebook.com/events/235534910388255/
 web_url_name: Facebook event
-last_modified_at: 2022-06-19
 date: 2018-08-16
 ---
 

--- a/_events/2018-08-28-swiss-watching-diccon.md
+++ b/_events/2018-08-28-swiss-watching-diccon.md
@@ -7,7 +7,6 @@ start_time: 7:00 pm
 end_time: 9:00 pm
 contact: Thomas
 cost: Free
-last_modified_at: 2022-06-19
 date: 2018-08-28
 ---
 

--- a/_events/2018-09-08-lady-muskoka.md
+++ b/_events/2018-09-08-lady-muskoka.md
@@ -8,7 +8,6 @@ contact: Paula
 cost: |
   $92 (members)
   $112 (guests)
-last_modified_at: 2022-06-19
 date: 2018-09-08
 ---
 

--- a/_events/2018-09-09-raclette-de-lamicale.md
+++ b/_events/2018-09-09-raclette-de-lamicale.md
@@ -10,7 +10,6 @@ cost: |
   $25 for Swiss club members
   $30 for guests
   $5 per car for parking (charged by the park)
-last_modified_at: 2022-06-19
 date: 2018-09-09
 ---
 

--- a/_events/2018-09-20-swiss-social-pub.md
+++ b/_events/2018-09-20-swiss-social-pub.md
@@ -8,7 +8,6 @@ end_time: 9 pm
 contact: Nadia
 web_url: https://www.facebook.com/events/501975370259448/
 web_url_name: Facebook event
-last_modified_at: 2022-06-19
 date: 2018-09-20
 ---
 

--- a/_events/2018-09-29-th-anniversary-gala.md
+++ b/_events/2018-09-29-th-anniversary-gala.md
@@ -9,7 +9,6 @@ contact: Denise
 cost: |
   $45 (members)
   $90 (non-members)
-last_modified_at: 2022-06-19
 date: 2018-09-29
 ---
 

--- a/_events/2018-10-12-une-part-dombre.md
+++ b/_events/2018-10-12-une-part-dombre.md
@@ -8,7 +8,6 @@ end_time: 8:30 pm
 web_url: http://2018.cinefranco.com/en/component/k2/item/513
 web_url_name: Cinéfranco
 cost: $10&ndash;$12
-last_modified_at: 2022-06-19
 date: 2018-10-12
 ---
 

--- a/_events/2018-10-25-swiss-social-pub.md
+++ b/_events/2018-10-25-swiss-social-pub.md
@@ -8,7 +8,6 @@ end_time: 9 pm
 contact: Nadia
 web_url: https://www.facebook.com/events/501975370259448/
 web_url_name: Facebook event
-last_modified_at: 2022-06-19
 date: 2018-10-25
 ---
 

--- a/_events/2018-10-29-mens-section.md
+++ b/_events/2018-10-29-mens-section.md
@@ -4,7 +4,6 @@ location: The Lindt Chocolate Store
 address: 2901 Bayview Ave, North York, ON M2K 1E6
 start_time: 10:15 am
 end_time: 12:00 pm
-last_modified_at: 2022-06-20
 date: 2018-10-29
 ---
 

--- a/_events/2018-10-29-theatre-performance.md
+++ b/_events/2018-10-29-theatre-performance.md
@@ -2,7 +2,6 @@
 title: Theatre performance
 location: Latvian Centre
 address: 4 Credit Union Dr, North York, ON M4A 2N8
-last_modified_at: 2022-06-20
 date: 2018-10-29
 ---
 

--- a/_events/2018-11-06-reception-and.md
+++ b/_events/2018-11-06-reception-and.md
@@ -7,7 +7,6 @@ end_time: 9:00 pm
 contact:
   name: Swiss Consulate General
   email: mon.newsletter@eda.admin.ch
-last_modified_at: 2022-06-20
 date: 2018-11-06
 ---
 

--- a/_events/2018-11-17-grand-raclette-gala.md
+++ b/_events/2018-11-17-grand-raclette-gala.md
@@ -8,7 +8,6 @@ web_url: http://www.swissbiz.ca/
 web_url_name: Swiss Canadian Chamber of Commerce
 contact:
   name: Swiss Canadian Chamber of Commerce
-last_modified_at: 2022-06-20
 date: 2018-11-17
 ---
 

--- a/_events/2018-11-18-swiss-movie-matinee.md
+++ b/_events/2018-11-18-swiss-movie-matinee.md
@@ -7,7 +7,6 @@ end_time: 5:00 pm
 cost: |
   Free for members
   $5 for non-members
-last_modified_at: 2022-06-20
 date: 2018-11-18
 ---
 

--- a/_events/2018-11-29-swiss-social-pub.md
+++ b/_events/2018-11-29-swiss-social-pub.md
@@ -8,7 +8,6 @@ end_time: 9 pm
 contact: Nadia
 web_url: https://www.facebook.com/events/501975370259448/
 web_url_name: Facebook event
-last_modified_at: 2022-06-20
 date: 2018-11-29
 ---
 

--- a/_events/2018-12-07-christmas-dinner.md
+++ b/_events/2018-12-07-christmas-dinner.md
@@ -4,7 +4,6 @@ location: St. George's Golf and Country Club
 address: 1668 Islington Ave, Etobicoke, ON M9A 3M9
 start_time: 11:45 am
 end_time: 3:45 pm
-last_modified_at: 2022-06-20
 date: 2018-12-07
 ---
 

--- a/_events/2018-12-20-swiss-social-pub.md
+++ b/_events/2018-12-20-swiss-social-pub.md
@@ -8,7 +8,6 @@ end_time: 9 pm
 contact: Nadia
 web_url: https://www.facebook.com/events/304938740354639/
 web_url_name: Facebook event
-last_modified_at: 2022-06-20
 date: 2018-12-20
 ---
 

--- a/_events/2019-01-17-mens-section-agm.md
+++ b/_events/2019-01-17-mens-section-agm.md
@@ -3,7 +3,6 @@ title: Men’s section annual general meeting
 location: St. George's Golf and Country Club
 address: 1668 Islington Ave, Etobicoke, ON M9A 3M9
 start_time: 11:45 am
-last_modified_at: 2022-06-13
 date: 2019-01-17
 ---
 

--- a/_events/2019-01-24-swiss-social-pub.md
+++ b/_events/2019-01-24-swiss-social-pub.md
@@ -7,7 +7,6 @@ contact: Nadia
 web_url: https://www.facebook.com/events/2000095330071900/
 web_url_name: Facebook event
 teaser: /assets/images/2020-01-23-pub-teaser.jpg
-last_modified_at: 2022-07-09
 date: 2019-01-24
 ---
 

--- a/_events/2019-01-26-amicale-romande.md
+++ b/_events/2019-01-26-amicale-romande.md
@@ -6,7 +6,6 @@ contact: Jean-Marc
 start_time: 7:00 pm
 end_time: 10:00 pm
 teaser: /assets/images/2020-01-25-amicale-teaser.jpg
-last_modified_at: 2022-07-09
 date: 2019-01-26
 ---
 

--- a/_events/2019-02-28-swiss-social-pub.md
+++ b/_events/2019-02-28-swiss-social-pub.md
@@ -7,7 +7,6 @@ web_url: https://www.facebook.com/events/1180232978811076/
 web_url_name: Facebook event
 start_time: 6:00 pm
 teaser: /assets/images/2019-02-28-pub-teaser.jpg
-last_modified_at: 2022-07-09
 date: 2019-02-28
 ---
 

--- a/_events/2019-03-09-rd-annual-canadysli.md
+++ b/_events/2019-03-09-rd-annual-canadysli.md
@@ -10,6 +10,5 @@ cost: |
   At the door: $55
 contact: Philippe
 teaser: /assets/images/2019-03-09-canadysli-teaser.png
-last_modified_at: 2022-07-09
 date: 2019-03-09
 ---

--- a/_events/2019-03-28-swiss-social-pub.md
+++ b/_events/2019-03-28-swiss-social-pub.md
@@ -8,7 +8,6 @@ contact: Nadia
 web_url: https://www.facebook.com/events/321583881798561/
 web_url_name: Facebook event
 teaser: /assets/images/2019-03-28-swiss-social-teaser.jpg
-last_modified_at: 2022-07-09
 date: 2019-03-28
 ---
 

--- a/_events/2019-04-25-swiss-social-pub.md
+++ b/_events/2019-04-25-swiss-social-pub.md
@@ -8,7 +8,6 @@ contact: Nadia
 web_url: https://www.facebook.com/events/2179175128795396/
 web_url_name: Facebook event
 teaser: /assets/images/2019-04-25-swiss-social-teaser.jpg
-last_modified_at: 2022-07-09
 date: 2019-04-25
 ---
 

--- a/_events/2019-04-26-annual-general.md
+++ b/_events/2019-04-26-annual-general.md
@@ -4,7 +4,6 @@ location: Chelsea Hotel
 address: 33 Gerrard St W, Toronto, ON M5G 1Z4
 start_time: 6:00 pm
 end_time: 11:00 pm
-last_modified_at: 2022-06-13
 date: 2019-04-26
 ---
 

--- a/_events/2019-04-28-swiss-theatre-group.md
+++ b/_events/2019-04-28-swiss-theatre-group.md
@@ -10,7 +10,6 @@ cost: |
   Non-members: $20
   Youth: $10
   Children: free
-last_modified_at: 2022-06-19
 date: 2019-04-28
 ---
 

--- a/_events/2019-05-11-blossom-time-in.md
+++ b/_events/2019-05-11-blossom-time-in.md
@@ -6,7 +6,6 @@ teaser: /assets/images/2019-05-11-blossom-teaser.jpg
 cost: |
   Swiss Club Toronto members: $75
   Guests: $82
-last_modified_at: 2022-07-09
 date: 2019-05-11
 ---
 

--- a/_events/2019-05-23-swiss-social-pub.md
+++ b/_events/2019-05-23-swiss-social-pub.md
@@ -8,7 +8,6 @@ contact: Nadia
 web_url: https://www.facebook.com/events/654106255050156/
 web_url_name: Facebook event
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-07-09
 date: 2019-05-23
 ---
 

--- a/_events/2019-06-07-woodbine-racetrack.md
+++ b/_events/2019-06-07-woodbine-racetrack.md
@@ -9,7 +9,6 @@ teaser: /assets/images/2019-06-07-woodbine-teaser.jpg
 cost: |
   Swiss Club members: $42
   Non-members: $52
-last_modified_at: 2022-07-09
 date: 2019-06-07
 ---
 

--- a/_events/2019-06-15-swiss-family-picnic.md
+++ b/_events/2019-06-15-swiss-family-picnic.md
@@ -9,6 +9,5 @@ teaser: /assets/images/2019-06-15-picnic-teaser.png
 cost: |
   $5 per person
   Free for members and children
-last_modified_at: 2022-07-09
 date: 2019-06-15
 ---

--- a/_events/2019-06-20-swiss-social-pub.md
+++ b/_events/2019-06-20-swiss-social-pub.md
@@ -8,7 +8,6 @@ contact: Nadia
 web_url: https://www.facebook.com/events/440196683422510/
 web_url_name: Facebook event
 teaser: /assets/images/2019-06-20-pub-teaser.jpg
-last_modified_at: 2022-07-09
 date: 2019-06-20
 ---
 

--- a/_events/2019-06-22-annual-bbq-at-the.md
+++ b/_events/2019-06-22-annual-bbq-at-the.md
@@ -5,7 +5,6 @@ start_time: 1:00 pm
 end_time: 4:00 pm
 contact: Arno
 teaser: /assets/images/2019-06-22-bbq-teaser.jpg
-last_modified_at: 2022-07-09
 date: 2019-06-22
 ---
 

--- a/_events/2019-07-16-port-dover-river.md
+++ b/_events/2019-07-16-port-dover-river.md
@@ -7,7 +7,6 @@ end_time: 8:15 pm
 cost: |
   $99 per person
   Includes motor coach transportation, cruise, lunch, all taxes, and meal tip
-last_modified_at: 2022-07-09
 date: 2019-07-16
 ---
 

--- a/_events/2019-07-28-swiss-national-day.md
+++ b/_events/2019-07-28-swiss-national-day.md
@@ -9,7 +9,6 @@ teaser: /assets/images/2019-06-22-snd-teaser.jpg
 cost: |
   Members and children: free
   Non-members: $10
-last_modified_at: 2022-07-09
 date: 2019-07-28
 ---
 

--- a/_events/2019-09-08-raclette-de-lamicale.md
+++ b/_events/2019-09-08-raclette-de-lamicale.md
@@ -9,7 +9,6 @@ cost: |
   For unlimited servings
   $30 for adults
   $10 for children under 12
-last_modified_at: 2022-06-19
 date: 2019-09-08
 ---
 

--- a/_events/2019-09-26-swiss-social-pub.md
+++ b/_events/2019-09-26-swiss-social-pub.md
@@ -8,7 +8,6 @@ contact: Nadia
 web_url: https://www.facebook.com/events/962287074113926/
 web_url_name: Facebook event
 teaser: /assets/images/2019-09-26-pub-teaser.jpg
-last_modified_at: 2022-07-09
 date: 2019-09-26
 ---
 

--- a/_events/2019-10-24-swiss-social-pub.md
+++ b/_events/2019-10-24-swiss-social-pub.md
@@ -8,7 +8,6 @@ contact: Nadia
 web_url: https://www.facebook.com/events/421617471792873/
 web_url_name: Facebook event
 teaser: /assets/images/2019-02-28-pub-teaser.jpg
-last_modified_at: 2022-07-09
 date: 2019-10-24
 ---
 

--- a/_events/2019-11-17-swiss-movie-matinee.md
+++ b/_events/2019-11-17-swiss-movie-matinee.md
@@ -5,7 +5,6 @@ address: 5801 Leslie St, North York, ON M2H 1J8
 start_time: 2:30 pm
 end_time: 5:00 pm
 teaser: /assets/images/2019-11-17-matinee-teaser.jpg
-last_modified_at: 2022-06-11
 date: 2019-11-17
 ---
 

--- a/_events/2020-01-23-swiss-social-pub.md
+++ b/_events/2020-01-23-swiss-social-pub.md
@@ -8,7 +8,6 @@ web_url_name: Facebook event
 start_time: 6:00 pm
 end_time: 9 pm
 teaser: /assets/images/2020-01-23-pub-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2020-01-23
 ---
 

--- a/_events/2020-01-25-amicale-romande.md
+++ b/_events/2020-01-25-amicale-romande.md
@@ -7,7 +7,6 @@ start_time: 7:00 pm
 end_time: 10:00 pm
 teaser: /assets/images/2020-01-25-amicale-teaser.jpg
 cost: $35
-last_modified_at: 2022-07-10
 date: 2020-01-25
 ---
 

--- a/_events/2020-02-27-swiss-social-pub.md
+++ b/_events/2020-02-27-swiss-social-pub.md
@@ -7,7 +7,6 @@ web_url_name: Facebook event
 start_time: 6:00 pm
 end_time: 8 pm
 teaser: /assets/images/2020-02-27-pub-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2020-02-27
 ---
 

--- a/_events/2020-03-07-canadysli-dinner.md
+++ b/_events/2020-03-07-canadysli-dinner.md
@@ -12,6 +12,5 @@ teaser: /assets/images/2020-03-07-canadysli-teaser.png
 cost: |
   $50 in advance
   $55 at the door
-last_modified_at: 2022-07-24
 date: 2020-03-07
 ---

--- a/_events/2020-03-15-cancelled-theatre.md
+++ b/_events/2020-03-15-cancelled-theatre.md
@@ -6,7 +6,6 @@ contact: Paula
 start_time: 2 pm
 end_time: 5 pm
 teaser: /assets/images/2020-03-15-people-teaser.jpg
-last_modified_at: 2022-07-09
 date: 2020-03-15
 ---
 

--- a/_events/2020-03-26-cancelled-swiss.md
+++ b/_events/2020-03-26-cancelled-swiss.md
@@ -7,7 +7,6 @@ web_url: https://www.facebook.com/events/1521302531358930
 web_url_name: Facebook event
 teaser: /assets/images/2020-03-26-pub-teaser.jpg
 start_time: 6:00 pm
-last_modified_at: 2022-07-09
 date: 2020-03-26
 ---
 

--- a/_events/2020-04-24-agm.md
+++ b/_events/2020-04-24-agm.md
@@ -4,7 +4,6 @@ date: 2020-04-24
 location: The Chelsea Hotel
 address: 33 Gerrard Street West, Toronto
 start_time: 6:30 pm
-last_modified_at: 2022-07-24
 ---
 This event has been cancelled.
 {: .notice--danger}

--- a/_events/2020-04-30-virtual-swiss-social.md
+++ b/_events/2020-04-30-virtual-swiss-social.md
@@ -6,7 +6,6 @@ web_url: https://www.facebook.com/events/613075645940231/
 web_url_name: Facebook event
 teaser: /assets/images/2020-04-30-pub-teaser.jpg
 start_time: 6:00 pm
-last_modified_at: 2022-06-26
 date: 2020-04-30
 ---
 

--- a/_events/2020-05-03-cancelled-swiss.md
+++ b/_events/2020-05-03-cancelled-swiss.md
@@ -5,7 +5,6 @@ address: 4 Credit Union Dr, North York, ON M4A 2N8
 start_time: 2:00 pm
 end_time: 5:00 pm
 teaser: /assets/images/2020-05-03-theatre-teaser.jpg
-last_modified_at: 2022-06-12
 date: 2020-05-03
 ---
 

--- a/_events/2020-05-28-online-swiss-social.md
+++ b/_events/2020-05-28-online-swiss-social.md
@@ -6,7 +6,6 @@ web_url: https://www.facebook.com/events/613075645940231/
 web_url_name: Facebook event
 start_time: 6:00 pm
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2020-05-28
 ---
 

--- a/_events/2020-05-29-cancelled-woodbine.md
+++ b/_events/2020-05-29-cancelled-woodbine.md
@@ -3,7 +3,6 @@ title: Woodbine Racetrack and Casino
 location: Woodbine Racetrack
 address: 555 Rexdale Blvd, Etobicoke, ON M9W 5L2
 start_time: 4:58 pm
-last_modified_at: 2022-06-12
 date: 2020-05-29
 ---
 

--- a/_events/2020-06-20-cancelled-bbq-at.md
+++ b/_events/2020-06-20-cancelled-bbq-at.md
@@ -1,7 +1,6 @@
 ---
 title: Annual BBQ
 location: Egger Dairy Farm
-last_modified_at: 2022-06-12
 date: 2020-06-20
 ---
 

--- a/_events/2020-06-25-swiss-social.md
+++ b/_events/2020-06-25-swiss-social.md
@@ -7,7 +7,6 @@ web_url: https://www.facebook.com/events/1158937581132442
 web_url_name: Facebook event
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2020-06-25
 ---
 

--- a/_events/2020-07-11-cancelled-wine-and.md
+++ b/_events/2020-07-11-cancelled-wine-and.md
@@ -1,6 +1,5 @@
 ---
 title: Wine and lavender tour
-last_modified_at: 2022-06-12
 date: 2020-07-11
 ---
 

--- a/_events/2020-07-26-cancelled-the-swiss.md
+++ b/_events/2020-07-26-cancelled-the-swiss.md
@@ -1,6 +1,5 @@
 ---
 title: Swiss National Day celebration 2020
-last_modified_at: 2022-06-12
 date: 2020-07-26
 ---
 

--- a/_events/2020-09-24-swiss-social.md
+++ b/_events/2020-09-24-swiss-social.md
@@ -7,7 +7,6 @@ web_url: https://www.facebook.com/events/682377479300264
 web_url_name: Facebook event
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2020-09-24
 ---
 

--- a/_events/2020-10-29-swiss-social.md
+++ b/_events/2020-10-29-swiss-social.md
@@ -7,7 +7,6 @@ web_url: https://www.facebook.com/events/460386764925568
 web_url_name: Facebook event
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2020-10-29
 ---
 

--- a/_events/2020-11-26-swiss-social.md
+++ b/_events/2020-11-26-swiss-social.md
@@ -7,7 +7,6 @@ web_url: https://www.facebook.com/events/370878190854070
 web_url_name: Facebook event
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2020-11-26
 ---
 

--- a/_events/2021-01-28-swiss-social.md
+++ b/_events/2021-01-28-swiss-social.md
@@ -7,7 +7,6 @@ web_url: https://www.facebook.com/events/1574054722786343
 web_url_name: Facebook event
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2021-01-28
 ---
 

--- a/_events/2021-02-25-swiss-social.md
+++ b/_events/2021-02-25-swiss-social.md
@@ -7,7 +7,6 @@ web_url: https://www.facebook.com/events/456716475375095
 web_url_name: Facebook event
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2021-02-25
 ---
 

--- a/_events/2021-03-25-swiss-social.md
+++ b/_events/2021-03-25-swiss-social.md
@@ -7,7 +7,6 @@ web_url: https://www.facebook.com/events/2805490403005064
 web_url_name: Facebook event
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2021-03-25
 ---
 

--- a/_events/2021-04-29-swiss-social.md
+++ b/_events/2021-04-29-swiss-social.md
@@ -7,7 +7,6 @@ web_url: https://www.facebook.com/events/977083426161541
 web_url_name: Facebook event
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2021-04-29
 ---
 

--- a/_events/2021-05-19-conference-virtuelle.md
+++ b/_events/2021-05-19-conference-virtuelle.md
@@ -7,7 +7,6 @@ web_url_name: Facebook event
 contact:
   name: La Société d'histoire de Toronto
 teaser: /assets/images/2021-05-19-conference-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2021-05-19
 ---
 

--- a/_events/2021-05-27-swiss-social.md
+++ b/_events/2021-05-27-swiss-social.md
@@ -7,7 +7,6 @@ web_url: https://www.facebook.com/events/2850321725216599/
 web_url_name: Facebook event
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2021-05-27
 ---
 

--- a/_events/2021-06-24-swiss-social.md
+++ b/_events/2021-06-24-swiss-social.md
@@ -7,7 +7,6 @@ web_url: https://www.facebook.com/events/492809151944495/
 web_url_name: Facebook event
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2021-06-24
 ---
 

--- a/_events/2021-07-02-soccer-spain.md
+++ b/_events/2021-07-02-soccer-spain.md
@@ -7,7 +7,6 @@ web_url: https://www.facebook.com/events/980403512728168/
 web_url_name: Facebook event
 contact: Charlotte
 teaser: /assets/images/2021-07-02-soccer-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2021-07-02
 ---
 

--- a/_events/2021-07-29-swiss-social.md
+++ b/_events/2021-07-29-swiss-social.md
@@ -8,7 +8,6 @@ web_url: https://www.facebook.com/events/360660355583115/
 web_url_name: Facebook event
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2021-07-29
 ---
 

--- a/_events/2021-08-26-swiss-social.md
+++ b/_events/2021-08-26-swiss-social.md
@@ -8,7 +8,6 @@ web_url: https://www.facebook.com/events/543092753572173/
 web_url_name: Facebook event
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2021-08-26
 ---
 

--- a/_events/2021-09-30-swiss-social.md
+++ b/_events/2021-09-30-swiss-social.md
@@ -8,7 +8,6 @@ web_url: https://www.facebook.com/events/409656123854704/
 web_url_name: Facebook event
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2021-09-30
 ---
 

--- a/_events/2021-10-28-swiss-social.md
+++ b/_events/2021-10-28-swiss-social.md
@@ -8,7 +8,6 @@ web_url: https://www.facebook.com/events/845501986123523/
 web_url_name: Facebook event
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2021-10-28
 ---
 

--- a/_events/2021-11-25-swiss-social.md
+++ b/_events/2021-11-25-swiss-social.md
@@ -8,7 +8,6 @@ start_time: 7 pm
 end_time: 8 pm
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2021-11-25
 ---
 

--- a/_events/2022-01-01-polar-bear.md
+++ b/_events/2022-01-01-polar-bear.md
@@ -7,7 +7,6 @@ web_url_name: Facebook event
 start_time: 11:30 am
 end_time: 1:30 pm
 contact: Charlotte
-last_modified_at: 2022-06-26
 date: 2022-01-01
 ---
 

--- a/_events/2022-01-27-swiss-social.md
+++ b/_events/2022-01-27-swiss-social.md
@@ -6,7 +6,6 @@ web_url_name: Facebook event
 start_time: 7 pm
 end_time: 8 pm
 contact: Charlotte
-last_modified_at: 2022-06-26
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
 date: 2022-01-27
 ---

--- a/_events/2022-02-24-swiss-social.md
+++ b/_events/2022-02-24-swiss-social.md
@@ -7,7 +7,6 @@ web_url_name: Facebook event
 start_time: 7 pm
 end_time: 8 pm
 contact: Charlotte
-last_modified_at: 2022-05-22
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
 date: 2022-02-24
 ---

--- a/_events/2022-04-07-swiss-social.md
+++ b/_events/2022-04-07-swiss-social.md
@@ -7,7 +7,6 @@ web_url_name: Facebook event
 start_time: 6 pm
 end_time: 8 pm
 contact: Charlotte
-last_modified_at: 2022-06-26
 teaser: /assets/images/2022-04-07-pubnight-teaser.jpg
 date: 2022-04-07
 ---

--- a/_events/2022-04-22-annual-general-meeting-2022.md
+++ b/_events/2022-04-22-annual-general-meeting-2022.md
@@ -8,7 +8,6 @@ end_time: 9:30 pm
 contacts:
   - Nadia
   - Heidy
-last_modified_at: 2022-07-24
 ---
 
 With things finally opening up, we are excited to announce that

--- a/_events/2022-04-28-sasha-huber.md
+++ b/_events/2022-04-28-sasha-huber.md
@@ -11,7 +11,6 @@ cost: |
   SCCC members: $15 for guided tour and one drink at The Goodman Pub and Kitchen
   Non-members: $15 for guided tour
 teaser: /assets/images/2022-04-28-huber-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2022-04-28
 ---
 

--- a/_events/2022-05-26-swiss-social.md
+++ b/_events/2022-05-26-swiss-social.md
@@ -8,7 +8,6 @@ start_time: 7 pm
 end_time: 8 pm
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-11
 date: 2022-05-26
 ---
 

--- a/_events/2022-06-25-bbq.md
+++ b/_events/2022-06-25-bbq.md
@@ -4,7 +4,6 @@ location: Egger dairy farm
 address: 5244 Steeles Avenue West, Milton, ON L9T 2Y1
 start_time: 1 pm
 contact: Arno
-last_modified_at: 2022-07-09
 date: 2022-06-25
 ---
 

--- a/_events/2022-06-30-swiss-social.md
+++ b/_events/2022-06-30-swiss-social.md
@@ -8,7 +8,6 @@ start_time: 7 pm
 end_time: 8 pm
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-06-26
 date: 2022-06-30
 ---
 

--- a/_events/2022-07-24-national-day.md
+++ b/_events/2022-07-24-national-day.md
@@ -9,7 +9,6 @@ end_time: 5 pm
 contact: Nadia
 cost: Free; food and drinks sold separately
 teaser: /assets/images/2022-07-24-national-day-teaser.jpg
-last_modified_at: 2022-06-19
 date: 2022-07-24
 ---
 

--- a/_events/2022-07-28-swiss-social-pub-night-july.md
+++ b/_events/2022-07-28-swiss-social-pub-night-july.md
@@ -10,7 +10,6 @@ end_time: 9:00 pm
 contacts:
   - Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-07-27
 ---
 Hi everyone!
 

--- a/_events/2022-07-30-canoe-trip.md
+++ b/_events/2022-07-30-canoe-trip.md
@@ -5,7 +5,6 @@ end_date: 2022-08-01
 contact: Walter
 cost: About $100 per person
 teaser: /assets/images/2022-07-30-canoe-teaser.jpg
-last_modified_at: 2022-07-01
 date: 2022-07-30
 ---
 

--- a/_events/2022-08-25-swiss-social.md
+++ b/_events/2022-08-25-swiss-social.md
@@ -8,7 +8,6 @@ start_time: 7 pm
 end_time: 9 pm
 contact: Charlotte
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-08-24
 date: 2022-08-25
 ---
 

--- a/_events/2022-09-11-raclette.md
+++ b/_events/2022-09-11-raclette.md
@@ -8,7 +8,6 @@ cost: |
   $30 per person
   The park will charge $5 per car for parking
 teaser: /assets/images/2022-09-11-raclette-teaser.jpg
-last_modified_at: 2022-07-01
 date: 2022-09-11
 ---
 

--- a/_events/2022-09-17-csa-reception.md
+++ b/_events/2022-09-17-csa-reception.md
@@ -8,7 +8,6 @@ contact:
   name: Peter Schürmann
   email: pschurmann@rogers.com
 teaser: /assets/images/2022-09-17-csa-teaser.jpg
-last_modified_at: 2022-09-04
 date: 2022-09-17
 ---
 

--- a/_events/2022-09-29-swiss-social.md
+++ b/_events/2022-09-29-swiss-social.md
@@ -8,7 +8,6 @@ start_time: 7 pm
 end_time: 9 pm
 contact: Ben
 teaser: /assets/images/2021-11-25-pubnight-teaser.jpg
-last_modified_at: 2022-09-28
 date: 2022-09-29
 ---
 

--- a/_events/2022-10-27-swiss-social.md
+++ b/_events/2022-10-27-swiss-social.md
@@ -8,7 +8,6 @@ start_time: 6 pm
 end_time: 9 pm
 contact: Charlotte
 teaser: /assets/images/2022-10-27-swiss-social-teaser.jpg
-last_modified_at: 2022-10-22
 date: 2022-10-27
 ---
 

--- a/_events/2022-10-29-swiss-movie-matinee.md
+++ b/_events/2022-10-29-swiss-movie-matinee.md
@@ -6,7 +6,6 @@ start_time: 1 pm
 contact: Arno
 cost: |
   Free for members of the Swiss Club and Swiss Canadian Chamber of Commerce
-last_modified_at: 2022-10-22
 date: 2022-10-29
 ---
 

--- a/_events/2022-11-30-mens-section-christmas-lunch.md
+++ b/_events/2022-11-30-mens-section-christmas-lunch.md
@@ -4,7 +4,6 @@ location: St. George's Golf and Country Club
 address: 1668 Islington Ave, Etobicoke
 start_time: 11:30 am
 contact: Arno
-last_modified_at: 2022-09-20
 date: 2022-11-30
 ---
 

--- a/_events/2022-12-02-soccer-viewing.md
+++ b/_events/2022-12-02-soccer-viewing.md
@@ -5,7 +5,6 @@ address: 33 Gerrard St W, Toronto
 contact: Arno
 teaser: /assets/images/2018-06-17-soccer-teaser.jpg
 date: 2022-12-02
-last_modified_at: 2022-11-12
 ---
 
 :warning: We've lost the room and currently don't think we'll be able to host a

--- a/_events/2023-01-20-mens-section-agm.md
+++ b/_events/2023-01-20-mens-section-agm.md
@@ -4,7 +4,6 @@ title: Men’s section annual general meeting
 # address: 1668 Islington Ave, Etobicoke, ON M9A 3M9
 # start_time: 11:45 am
 contact: arno
-last_modified_at: 2022-11-12
 date: 2023-01-20
 ---
 

--- a/_gallery/2015-04-30-trillium.md
+++ b/_gallery/2015-04-30-trillium.md
@@ -1,7 +1,6 @@
 ---
 title: Trillium Alphorn Players Toronto
 author: Swiss Club Toronto
-last_modified_at: 2022-05-22
 header:
   teaser: /assets/images/2015-04-30-trillium-02-th.jpg
 gallery:

--- a/_gallery/2015-07-26-national-day.md
+++ b/_gallery/2015-07-26-national-day.md
@@ -1,7 +1,6 @@
 ---
 title: Swiss National Day celebration 2015
 author: Swiss Club Toronto
-last_modified_at: 2022-05-23
 header:
   teaser: /assets/images/2015-07-26-national-day-01-th.jpg
 gallery:

--- a/_gallery/2016-08-17-national-day.md
+++ b/_gallery/2016-08-17-national-day.md
@@ -1,7 +1,6 @@
 ---
 title: Swiss National Day celebration 2016
 author: Swiss Club Toronto
-last_modified_at: 2022-05-23
 header:
   teaser: /assets/images/2016-08-17-national-day-01-th.jpg
 gallery:

--- a/_gallery/2016-09-27-high-park.md
+++ b/_gallery/2016-09-27-high-park.md
@@ -1,7 +1,6 @@
 ---
 title: Women's Section lunch and High Park zoo visit
 author: Swiss Club Toronto
-last_modified_at: 2022-05-23
 header:
   teaser: /assets/images/2016-09-27-high-park-01-th.jpg
 gallery:

--- a/_gallery/2017-06-14-woodbine.md
+++ b/_gallery/2017-06-14-woodbine.md
@@ -1,7 +1,6 @@
 ---
 title: Woodbine luncheon 2017
 author: Swiss Club Toronto
-last_modified_at: 2022-05-23
 header:
   teaser: /assets/images/2017-06-14-woodbine-01-th.jpg
 gallery:

--- a/_gallery/2017-08-07-national-day.md
+++ b/_gallery/2017-08-07-national-day.md
@@ -1,7 +1,6 @@
 ---
 title: Swiss National Day celebration 2017
 author: Swiss Club Toronto
-last_modified_at: 2022-05-23
 header:
   teaser: /assets/images/2017-08-07-national-day-01-th.jpg
 gallery:

--- a/_gallery/2017-08-13-kajama.md
+++ b/_gallery/2017-08-13-kajama.md
@@ -1,7 +1,6 @@
 ---
 title: Kajama cruise
 author: Swiss Club Toronto
-last_modified_at: 2022-05-23
 header:
   teaser: /assets/images/2017-08-13-kajama-01-th.jpg
 gallery:

--- a/_gallery/2017-09-12-raclette.md
+++ b/_gallery/2017-09-12-raclette.md
@@ -1,7 +1,6 @@
 ---
 title: Raclette de l'Amicale Romande 2017
 author: Swiss Club Toronto
-last_modified_at: 2022-05-23
 header:
   teaser: /assets/images/2017-09-12-raclette-01-th.jpg
 gallery:

--- a/_gallery/2017-09-12-zoo.md
+++ b/_gallery/2017-09-12-zoo.md
@@ -1,7 +1,6 @@
 ---
 title: Zoo trip 2017
 author: Swiss Club Toronto
-last_modified_at: 2022-05-23
 header:
   teaser: /assets/images/2017-09-12-zoo-01-th.jpg
 gallery:

--- a/_gallery/2017-10-27-simcoe-train.md
+++ b/_gallery/2017-10-27-simcoe-train.md
@@ -1,7 +1,6 @@
 ---
 title: South Simcoe train ride 2017
 author: Swiss Club Toronto
-last_modified_at: 2022-05-23
 header:
   teaser: /assets/images/2017-10-27-simcoe-train-01-th.jpg
 gallery:

--- a/_gallery/2018-02-07-brewery-tour.md
+++ b/_gallery/2018-02-07-brewery-tour.md
@@ -1,7 +1,6 @@
 ---
 title: Swiss Academics brewery tour 2018
 author: Swiss Club Toronto
-last_modified_at: 2022-05-23
 header:
   teaser: /assets/images/2018-02-07-brewery-tour-01-th.jpg
 gallery:

--- a/_gallery/2018-03-12-canadysli-dinner.md
+++ b/_gallery/2018-03-12-canadysli-dinner.md
@@ -1,7 +1,6 @@
 ---
 title: Canadysli dinner and dance 2018
 author: Swiss Club Toronto
-last_modified_at: 2022-05-23
 header:
   teaser: /assets/images/2018-03-12-canadysli-dinner-01-th.jpg
 gallery:

--- a/_gallery/2018-03-19-amicale-romande.md
+++ b/_gallery/2018-03-19-amicale-romande.md
@@ -1,7 +1,6 @@
 ---
 title: Fondue de l'Amicale Romande 2018
 author: Swiss Club Toronto
-last_modified_at: 2022-05-23
 header:
   teaser: /assets/images/2018-03-19-amicale-romande-01-th.jpg
 gallery:

--- a/_gallery/2018-04-22-theatre.md
+++ b/_gallery/2018-04-22-theatre.md
@@ -1,7 +1,6 @@
 ---
 title: Miss Sophie's Erbe---Theatre 2018
 author: Thomas Guignard
-last_modified_at: 2022-05-23
 header:
   teaser: /assets/images/2018-04-22-theatre-01-th.jpg
 gallery:

--- a/_gallery/2018-08-31-national-day.md
+++ b/_gallery/2018-08-31-national-day.md
@@ -1,7 +1,6 @@
 ---
 title: Swiss National Day celebration 2018
 author: Thomas Guignard
-last_modified_at: 2022-05-23
 header:
   teaser: /assets/images/2018-08-31-national-day-01-th.jpg
 gallery:

--- a/_gallery/2018-09-03-flag-raising.md
+++ b/_gallery/2018-09-03-flag-raising.md
@@ -1,7 +1,6 @@
 ---
 title: Flag raising at City Hall August 1st 2018
 author: Thomas Guignard
-last_modified_at: 2022-05-24
 header:
   teaser: /assets/images/2018-09-03-flag-raising-01-th.jpg
 gallery:

--- a/_gallery/2018-09-10-lady-muskoka.md
+++ b/_gallery/2018-09-10-lady-muskoka.md
@@ -1,7 +1,6 @@
 ---
 title: Lady Muskoka anniversary cruise
 author: Thomas Guignard
-last_modified_at: 2022-05-24
 header:
   teaser: /assets/images/2018-09-10-lady-muskoka-01-th.jpg
 gallery:

--- a/_gallery/2018-09-10-raclette.md
+++ b/_gallery/2018-09-10-raclette.md
@@ -1,7 +1,6 @@
 ---
 title: Raclette de l'Amicale Romande 2018
 author: Thomas Guignard
-last_modified_at: 2022-05-24
 header:
   teaser: /assets/images/2018-09-10-raclette-01-th.jpg
 gallery:

--- a/_gallery/2018-09-11-swiss-watching.md
+++ b/_gallery/2018-09-11-swiss-watching.md
@@ -1,7 +1,6 @@
 ---
 title: Swiss Watching
 author: Thomas Guignard
-last_modified_at: 2022-05-24
 header:
   teaser: /assets/images/2018-09-11-swiss-watching-01-th.jpg
 gallery:

--- a/_gallery/2018-10-01-gala.md
+++ b/_gallery/2018-10-01-gala.md
@@ -1,7 +1,6 @@
 ---
 title: 100th anniversary gala
 author: Thomas Guignard
-last_modified_at: 2022-05-24
 header:
   teaser: /assets/images/2018-10-01-gala-001-th.jpg
 gallery:

--- a/_gallery/2019-03-12-canadysli-dinner.md
+++ b/_gallery/2019-03-12-canadysli-dinner.md
@@ -1,7 +1,6 @@
 ---
 title: Canadysli dinner and dance 2019
 author: Swiss Club Toronto
-last_modified_at: 2022-05-24
 header:
   teaser: /assets/images/2019-03-12-canadysli-dinner-002-th.jpg
 gallery:

--- a/_gallery/2019-04-29-theatre.md
+++ b/_gallery/2019-04-29-theatre.md
@@ -1,7 +1,6 @@
 ---
 title: Im Meischter sini Geischter---Theatre 2019
 author: Thomas Guignard
-last_modified_at: 2022-05-24
 header:
   teaser: /assets/images/2019-04-29-theatre-001-th.jpg
 gallery:

--- a/_gallery/2019-07-31-national-day.md
+++ b/_gallery/2019-07-31-national-day.md
@@ -1,7 +1,6 @@
 ---
 title: Swiss National Day celebration 2019
 author: Thomas Guignard
-last_modified_at: 2022-05-24
 header:
   teaser: /assets/images/2019-07-31-national-day-001-th.jpg
 gallery:

--- a/_gallery/2019-09-08-raclette.md
+++ b/_gallery/2019-09-08-raclette.md
@@ -1,7 +1,6 @@
 ---
 title: Raclette de l'Amicale Romande 2019
 author: Thomas Guignard
-last_modified_at: 2022-05-24
 header:
   teaser: /assets/images/2019-09-08-raclette-001-th.jpg
 gallery:

--- a/_gallery/2019-10-25-womens-section.md
+++ b/_gallery/2019-10-25-womens-section.md
@@ -1,7 +1,6 @@
 ---
 title: Women's Section 2018
 author: Swiss Club toronto
-last_modified_at: 2022-05-24
 header:
   teaser: /assets/images/2019-10-25-womens-section-001-th.jpg
 gallery:

--- a/_gallery/2020-01-26-amicale-romande.md
+++ b/_gallery/2020-01-26-amicale-romande.md
@@ -1,7 +1,6 @@
 ---
 title: Fondue de l'Amicale Romande 2020
 author: Thomas Guignard
-last_modified_at: 2022-05-22
 header:
   teaser: /assets/images/2020-01-26-amicale-romande-01-th.jpg
 gallery:

--- a/_gallery/2022-07-24-national-day.md
+++ b/_gallery/2022-07-24-national-day.md
@@ -1,6 +1,5 @@
 ---
 title: Swiss National Day celebration 2022
-last_modified_at: 2022-07-26
 header:
   teaser: /assets/images/2022-07-24-national-day-001-th.jpg
 gallery:

--- a/_gallery/2022-09-11-raclette.md
+++ b/_gallery/2022-09-11-raclette.md
@@ -1,6 +1,5 @@
 ---
 title: Raclette de l'Amicale Romande 2022
-last_modified_at: 2022-09-20
 header:
   teaser: /assets/images/2022-09-11-raclette-016-th.jpg
 gallery:

--- a/_posts/2017-02-10-aso.md
+++ b/_posts/2017-02-10-aso.md
@@ -1,7 +1,6 @@
 ---
 title: Council of the Swiss Abroad 2017
 author: Ernst Notz
-last_modified_at: 2022-05-23
 tag: aso
 ---
 

--- a/_posts/2018-04-16-important-message.md
+++ b/_posts/2018-04-16-important-message.md
@@ -1,7 +1,6 @@
 ---
 title: Important message to all Swiss Citizens residing in Ontario
 author: Swiss Club Toronto
-last_modified_at: 2019-08-29
 tag: info
 ---
 

--- a/_posts/2018-08-12-aso-congress.md
+++ b/_posts/2018-08-12-aso-congress.md
@@ -1,7 +1,6 @@
 ---
 title: Report from the ASO congress
 author: Florence Pasche Guignard
-last_modified_at: 2022-05-23
 tag: aso
 figure:
   image_path: /assets/images/2018-08-12-aso-congress.jpg

--- a/_posts/2021-03-11-aso-application.md
+++ b/_posts/2021-03-11-aso-application.md
@@ -1,7 +1,6 @@
 ---
 title: Application deadline for new ASO delegates
 author: Swiss Club Toronto
-last_modified_at: 2022-05-23
 tag: aso
 ---
 

--- a/_posts/2022-05-19-women-agm.md
+++ b/_posts/2022-05-19-women-agm.md
@@ -1,7 +1,6 @@
 ---
 title: Women's section report for the 2022 AGM
 author: Swiss Club Toronto
-last_modified_at: 2022-06-22
 ---
 
 The annual general meeting took place at the St. George's Golf and Country Club

--- a/_posts/2022-07-01-womens-section.md
+++ b/_posts/2022-07-01-womens-section.md
@@ -1,7 +1,6 @@
 ---
 title: News from the Women's Section
 author: Paula Rico
-last_modified_at: 2022-07-01
 ---
 
 Our Kaffeeklatsches are the first Wednesday of the month at the new location,

--- a/_posts/2022-07-16-congress.md
+++ b/_posts/2022-07-16-congress.md
@@ -1,6 +1,5 @@
 ---
 title: Register for the Congress of the Swiss Abroad
-last_modified_at: 2022-07-16
 ---
 
 The 98th Congress of the Swiss Abroad takes place in Lugano from August 19 to

--- a/_posts/2022-07-23-snd-program.md
+++ b/_posts/2022-07-23-snd-program.md
@@ -1,6 +1,5 @@
 ---
 title: Swiss National Day program 2022
-last_modified_at: 2022-07-23
 ---
 
 The program for the Swiss National Day celebration for tomorrow, July 24, 2022,

--- a/_posts/2022-07-29-swissinfo-video-questions-request.md
+++ b/_posts/2022-07-29-swissinfo-video-questions-request.md
@@ -1,7 +1,6 @@
 ---
 title: Swissinfo video questions request
 author: Swiss Club Toronto
-last_modified_at: 2022-07-29
 ---
 Swissinfo is looking for short videos from Swiss abroad:
 

--- a/_posts/2022-09-09-how-i-got-here.md
+++ b/_posts/2022-09-09-how-i-got-here.md
@@ -1,7 +1,6 @@
 ---
 title: How I Got Here---casting inquiry
 author: Swiss Club Toronto
-last_modified_at: 2022-09-09
 ---
 
 We got a casting inquiry for a show looking to accompany North-American born

--- a/_posts/2022-09-20-aso-congress.md
+++ b/_posts/2022-09-20-aso-congress.md
@@ -1,7 +1,6 @@
 ---
 title: Report from the 2022 ASO Congress in Lugano
 author: Swiss Club Toronto
-last_modified_at: 2022-09-20
 ---
 
 A delegation of six representatives of the Swiss in Canada---including our own

--- a/_posts/2022-10-01-fabio-andina.md
+++ b/_posts/2022-10-01-fabio-andina.md
@@ -1,7 +1,6 @@
 ---
 title: An evening of Italian Poetry
 author: Swiss Club Toronto
-last_modified_at: 2022-10-01
 ---
 
 ![Fabio Andina and Guido Catalano]({% link /assets/images/2022-10-01-fabio-andina.jpg %})

--- a/_posts/2022-10-22-update.md
+++ b/_posts/2022-10-22-update.md
@@ -1,7 +1,6 @@
 ---
 title: October events
 author: Swiss Club Toronto
-last_modified_at: 2022-10-22
 ---
 
 Head over to the events page and have a look at our upcoming events for October:

--- a/_posts/2022-10-29-canadysli.md
+++ b/_posts/2022-10-29-canadysli.md
@@ -1,7 +1,6 @@
 ---
 title: Canadysli practice
 author: Swiss Club Toronto
-last_modified_at: 2022-10-29
 ---
 
 Our friends at the [Canadysli Toronto Guggemusig Band][canadysli] are starting

--- a/_posts/2022-11-11-csa-meeting.md
+++ b/_posts/2022-11-11-csa-meeting.md
@@ -1,7 +1,6 @@
 ---
 title: November 2022 CSA meeting
 author: Swiss Club Toronto
-last_modified_at: 2022-11-13 20:50:30
 ---
 
 The Council of the Swiss Abroad (CSA) recently held its virtual November


### PR DESCRIPTION
Doesn't actually fix the RSS issue; as per [Mailchimp docs](https://mailchimp.com/en-ca/help/troubleshooting-rss-in-campaigns/), the following tags are considered in order

- `pubDate`
- `pubdate`
- `published`
- `created`
- `updated`

The generated RSS feed looks like this:

```xml
<feed xmlns="http://www.w3.org/2005/Atom">
  <generator uri="https://jekyllrb.com/" version="4.3.1">Jekyll</generator>
  <link href="http://localhost:4000/feed.xml" rel="self" type="application/atom+xml"/>
  <link href="http://localhost:4000/" rel="alternate" type="text/html"/>
  <updated>2022-11-14T21:53:23-05:00</updated>
  <id>http://localhost:4000/feed.xml</id>
  <title type="html">Swiss Club Toronto</title>
  <subtitle>Subtitle</subtitle>
  <entry>
    <title type="html">November 2022 CSA meeting</title>
    <link href="http://localhost:4000/2022/11/11/csa-meeting/" rel="alternate" type="text/html" title="November 2022 CSA meeting"/>
    <published>2022-11-11T00:00:00-05:00</published>
    <updated>2022-11-13T15:50:30-05:00</updated>
    <id>http://localhost:4000/2022/11/11/csa-meeting</id>
    <content type="html" xml:base="http://localhost:4000/2022/11/11/csa-meeting/">
    Content
    </content>
    <author>
      <name>Swiss Club Toronto</name>
    </author>
    <summary type="html">
    Summary
    </summary>
   </entry>
```

The added plugin updates the `updated` tag, but doesn't change the `published` tag. It's worth using it anyway, though, to get rid of having to manually update the front matter &ndash; but it won't fix the RSS feed.
