### PR TITLE
Add author field for texting

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -52,7 +52,7 @@ charlotte:
   links:
     - label: Phone
       icon: fas fa-fw fa-phone
-      url: tel:647-473-8941
+      url: tel:437-881-3940
 
 denise:
   name: Denise Frassini

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -53,6 +53,9 @@ charlotte:
     - label: Phone
       icon: fas fa-fw fa-phone
       url: tel:437-881-3940
+    - label: Messaging
+      icon: fas fa-fw fa-sms
+      url: tel:647-473-8941
 
 denise:
   name: Denise Frassini

--- a/_includes/event-contact.html
+++ b/_includes/event-contact.html
@@ -4,11 +4,14 @@
 {%- if include.contact.name -%}
   {%- assign contact = include.contact -%}
   {%- assign tel = contact.tel -%}
+  {%- assign txt = contact.txt -%}
 {%- else -%}
   {%- assign key = include.contact | downcase -%}
   {%- assign contact = site.data.authors[key] -%}
   {%- assign tel_obj = contact.links | find: "label", "Phone" -%}
   {%- assign tel = tel_obj.url | remove_first: "tel:" -%}
+  {%- assign txt_obj = contact.links | find: "label", "Messaging" -%}
+  {%- assign txt = txt_obj.url | remove_first: "tel:" -%}
 {%- endif -%}
 {%- if contact.name -%}
   <i class="fas fa-fw fa-user"></i>
@@ -21,4 +24,8 @@
 {%- if tel != "" and tel != nil -%}
   <i class="fas fa-fw fa-phone"></i>
   <a href="tel:{{ tel }}">{{ tel }}</a><br>
+{%- endif -%}
+{%- if txt != "" and txt != nil -%}
+  <i class="fas fa-fw fa-sms"></i>
+  <a href="tel:{{ txt }}">{{ txt }}</a><br>
 {%- endif -%}


### PR DESCRIPTION
Add separate field for phone number to be used for messaging; in `authors.yml` as a link with label "Messaging", and in front matter as `author.txt`.